### PR TITLE
Rename new command to add

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ rpilot init
 - Add a new env profile
 
 ```
-rpilot new --name default
+rpilot add --name default
 ```
 
 - Apply the specific profile

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,8 +1,8 @@
+pub mod add;
 pub mod apply;
 pub mod current;
 pub mod edit;
 pub mod init;
 pub mod list;
-pub mod new;
 pub mod remove;
 pub mod show;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,18 +3,18 @@ use structopt::StructOpt;
 
 pub mod commands;
 pub mod common;
+use commands::add;
 use commands::apply;
 use commands::current;
 use commands::edit;
 use commands::init;
 use commands::list;
-use commands::new;
 use commands::remove;
 use commands::show;
 
 #[derive(Debug, PartialEq, StructOpt)]
 enum Rpilot {
-    New(new::Args),
+    Add(add::Args),
     Init,
     List,
     Current,
@@ -29,7 +29,7 @@ fn main() {
     env_logger::init_from_env(env);
 
     match Rpilot::from_args() {
-        Rpilot::New(v) => new::execute(&v),
+        Rpilot::Add(v) => add::execute(&v),
         Rpilot::Init => init::execute(),
         Rpilot::List => list::execute(),
         Rpilot::Current => current::execute(),


### PR DESCRIPTION
## Overview
- Rename `rpilot new` to `rpilot add` to be consistent with other command names